### PR TITLE
feat: Add API documentation tool with Spring REST Docs and OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build
 
 ### User Service ###
 service/user/.env
+service/user/src/main/resources/static/api-docs/openapi3.yml

--- a/service/user/.env.user-service
+++ b/service/user/.env.user-service
@@ -1,16 +1,18 @@
 # Docker Compose Environment Variables for User Service
 DOCKER_REGISTRY=myregistry.com
 
+# User Service Configuration
+PROTOCOL=http
+SERVER_HOST=13.124.188.47
+SERVER_PORT=9000
+HEALTH_CHECK_PATH=/health
+
 # MySQL Configuration
 MYSQL_HOST=mysql
 
 # Redis Configuration
 REDIS_HOST=redis
 
-# Application Configuration
-SERVER_HOST=13.124.188.47
-SERVER_PORT=9000
-HEALTH_CHECK_PATH=/health
 ## JPA Configuration
 JPA_SHOW_SQL=false
 JPA_HIBERNATE_DDL_AUTO=validate

--- a/service/user/build.gradle.kts
+++ b/service/user/build.gradle.kts
@@ -1,5 +1,16 @@
 group = "${rootProject.group}.user"
 
+plugins {
+    // RestDocs API Spec - Spring REST Docs와 OpenAPI 통합
+    id("com.epages.restdocs-api-spec") version "0.19.0"
+}
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://plugins.gradle.org/m2/") }
+    maven { url = uri("https://jitpack.io") }
+}
+
 dependencies {
 
     // Spring Boot Web - REST API 개발
@@ -26,4 +37,42 @@ dependencies {
     testImplementation("org.testcontainers:mysql")
     // Kotlin 데이터 클래스 직렬화 지원
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+    // Spring REST Docs
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+
+    // RestDocs API Spec - Spring REST Docs와 OpenAPI 통합
+    testImplementation("com.epages:restdocs-api-spec-mockmvc:0.19.0")
+
+    // Swagger UI - OpenAPI 문서 시각화
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+}
+
+// OpenAPI 3.0.1 문서 생성 설정
+openapi3 {
+    val port = System.getenv("PORT") ?: "9000"
+    val host = System.getenv("HOST") ?: "localhost"
+    val protocol = System.getenv("PROTOCOL") ?: "http"
+
+    // 단일 서버 설정
+    setServer("$protocol://$host:$port")
+
+    title = "TechWikiPlus User Service API"
+    description = "User Service API Documentation"
+    version = System.getenv("VERSION") ?: "LOCAL_VERSION"
+    format = "yml"
+    outputDirectory = "build/api-spec"
+    snippetsDirectory = "build/generated-snippets"
+}
+
+// OpenAPI 문서를 정적 리소스로 복사하는 태스크
+tasks.register<Copy>("copyOpenApiToResources") {
+    dependsOn("openapi3")
+    from("build/api-spec/openapi3.yml")
+    into("src/main/resources/static/api-docs")
+}
+
+// 테스트 실행 후 자동으로 OpenAPI 문서 생성 및 복사
+tasks.named("test") {
+    finalizedBy("copyOpenApiToResources")
 }

--- a/service/user/build.gradle.kts
+++ b/service/user/build.gradle.kts
@@ -50,16 +50,16 @@ dependencies {
 
 // OpenAPI 3.0.1 문서 생성 설정
 openapi3 {
-    val port = System.getenv("PORT") ?: "9000"
-    val host = System.getenv("HOST") ?: "localhost"
     val protocol = System.getenv("PROTOCOL") ?: "http"
+    val host = System.getenv("SERVER_HOST") ?: "localhost"
+    val port = System.getenv("SERVER_PORT") ?: "9000"
 
     // 단일 서버 설정
     setServer("$protocol://$host:$port")
 
     title = "TechWikiPlus User Service API"
     description = "User Service API Documentation"
-    version = System.getenv("VERSION") ?: "LOCAL_VERSION"
+    version = System.getenv("IMAGE_TAG") ?: "LOCAL_VERSION"
     format = "yml"
     outputDirectory = "build/api-spec"
     snippetsDirectory = "build/generated-snippets"

--- a/service/user/docker/docker-compose.user-service.yml
+++ b/service/user/docker/docker-compose.user-service.yml
@@ -40,6 +40,10 @@ services:
     environment:
       # 애플리케이션 설정
       - IMAGE_TAG=${IMAGE_TAG}              # 이미지 태그 (CI/CD에서 동적 변경 가능)
+      - PROTOCOL=${PROTOCOL}              # 프로토콜 (http 또는 https)
+      - SERVER_HOST=${SERVER_HOST}          # 애플리케이션 호스트 (기본: localhost)
+      - SERVER_PORT=${SERVER_PORT}          # 애플리케이션 포트 (기본: 9000)
+
       # MySQL 연결 설정
       - MYSQL_HOST=${MYSQL_HOST}            # MySQL 서버 주소
       - MYSQL_PORT=${MYSQL_PORT}            # MySQL 포트 (기본: 3306)

--- a/service/user/docs/README.md
+++ b/service/user/docs/README.md
@@ -21,28 +21,27 @@
 #### 1. 서비스 시작
 
 ```bash
-# 1. config 디렉토리의 .env.example 파일을 .env.base로 복사 후 설정 값에 맞게 수정
-cp config/.env.example .env.base & cp config/.env.local.example .env.local
+# 1. .env.base, .env.mail 파일에 각 환경에 맞는 설정 값 입력
 
 # 2. Docker Compose로 서비스 시작
-docker compose --env-file .env.base --env-file .env.local -f docker/docker-compose.base.yml -f docker/docker-compose.local.yml up -d
+docker compose --env-file .env.base --env-file .env.mail -f docker/docker-compose.base.yml -f docker/docker-compose.mail.yml up -d
 ```
 
 #### 2. 서비스 상태 확인
 
 ```bash
 # 실행 중인 컨테이너 확인
-docker compose --env-file .env.base --env-file .env.local -f docker/docker-compose.base.yml -f docker/docker-compose.local.yml ps
+docker compose --env-file .env.base --env-file .env.mail -f docker/docker-compose.base.yml -f docker/docker-compose.mail.yml ps
 ```
 
 #### 3. 서비스 중지
 
 ```bash
 # 서비스 중지 및 컨테이너 제거
-docker compose --env-file .env.base --env-file .env.local -f docker/docker-compose.base.yml -f docker/docker-compose.local.yml down
+docker compose --env-file .env.base --env-file .env.mail -f docker/docker-compose.base.yml -f docker/docker-compose.mail.yml down
 
 # 볼륨까지 모두 제거 (데이터 초기화)
-docker compose --env-file .env.base --env-file .env.local -f docker/docker-compose.base.yml -f docker/docker-compose.local.yml down -v
+docker compose --env-file .env.base --env-file .env.mail -f docker/docker-compose.base.yml -f docker/docker-compose.mail.yml down -v
 ```
 
 ### Production 환경
@@ -50,26 +49,25 @@ docker compose --env-file .env.base --env-file .env.local -f docker/docker-compo
 #### 1. 서비스 시작
 
 ```bash
-# 1. config 디렉토리의 .env.example 파일을 .env.base로 복사 후 설정 값에 맞게 수정
-cp config/.env.example .env.base & cp config/.env.prod.example .env.prod
+# 1. .env.base, .env.user-service 파일에 각 환경에 맞는 설정 값 입력
 
 # 2. Docker Compose로 서비스 시작
-docker compose --env-file .env.base --env-file .env.prod -f docker/docker-compose.base.yml -f docker/docker-compose.prod.yml up -d
+docker compose --env-file .env.base --env-file .env.user-service -f docker/docker-compose.base.yml -f docker/docker-compose.user-service.yml up -d
 ```
 
 #### 2. 서비스 상태 확인
 
 ```bash
 # 실행 중인 컨테이너 확인
-docker compose --env-file .env.base --env-file .env.prod -f docker/docker-compose.base.yml -f docker/docker-compose.prod.yml ps
+docker compose --env-file .env.base --env-file .env.user-service -f docker/docker-compose.base.yml -f docker/docker-compose.user-service.yml ps
 ```
 
 #### 3. 서비스 중지
 
 ```bash
 # 서비스 중지 및 컨테이너 제거
-docker compose --env-file .env.base --env-file .env.prod -f docker/docker-compose.base.yml -f docker/docker-compose.prod.yml down
+docker compose --env-file .env.base --env-file .env.user-service -f docker/docker-compose.base.yml -f docker/docker-compose.user-service.yml down
 
 # 볼륨까지 모두 제거 (데이터 초기화)
-docker compose --env-file .env.base --env-file .env.prod -f docker/docker-compose.base.yml -f docker/docker-compose.prod.yml down -v
+docker compose --env-file .env.base --env-file .env.user-service -f docker/docker-compose.base.yml -f docker/docker-compose.user-service.yml down -v
 ```

--- a/service/user/src/main/kotlin/me/helloc/techwikiplus/infrastructure/apidocs/StaticRoutingConfiguration.kt
+++ b/service/user/src/main/kotlin/me/helloc/techwikiplus/infrastructure/apidocs/StaticRoutingConfiguration.kt
@@ -1,0 +1,20 @@
+package me.helloc.techwikiplus.infrastructure.apidocs
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * 정적 리소스 라우팅 설정
+ *
+ * REST Docs로 생성된 OpenAPI 문서를 제공하기 위한 설정입니다.
+ */
+@Configuration
+class StaticRoutingConfiguration : WebMvcConfigurer {
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        // REST Docs로 생성된 API 문서 제공
+        registry
+            .addResourceHandler("/api-docs/**")
+            .addResourceLocations("classpath:/static/api-docs/")
+    }
+}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       idle-timeout: 600000 # 유휴 커넥션 타임아웃 (10분)
       max-lifetime: 1800000 # 커넥션 최대 생명주기 (30분)
   jpa:
-    database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
     show-sql: ${JPA_SHOW_SQL:false}  # 성능 최적화를 위해 비활성화
     hibernate:
@@ -38,8 +37,9 @@ spring:
           use_second_level_cache: false
           use_query_cache: false
         # 메타데이터 최적화
-        temp:
-          use_jdbc_metadata_defaults: false
+        # JDBC 메타데이터 접근 허용 (자동 dialect 감지를 위해 필요)
+        boot:
+          allow_jdbc_metadata_access: true
 
 # Springdoc OpenAPI 설정
 # REST Docs로 생성된 OpenAPI 문서를 Swagger UI로 표시

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -42,14 +42,13 @@ spring:
           use_jdbc_metadata_defaults: false
 
 # Springdoc OpenAPI 설정
+# REST Docs로 생성된 OpenAPI 문서를 Swagger UI로 표시
 # API 문서 접근 경로:
-# - OpenAPI JSON: http://localhost:9000/v3/api-docs
-# - OpenAPI YAML: http://localhost:9000/v3/api-docs.yaml
+# - OpenAPI YAML: http://localhost:9000/api-docs/openapi3.yml (REST Docs로 생성)
 # - Swagger UI: http://localhost:9000/swagger-ui/index.html
 springdoc:
   api-docs:
-    enabled: true
-    path: /v3/api-docs
+    enabled: true  # Swagger UI가 작동하려면 활성화 필요
   swagger-ui:
     enabled: true
-    path: /swagger-ui.html
+    url: /api-docs/openapi3.yml  # REST Docs로 생성된 OpenAPI 문서 경로 지정

--- a/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/ApiDocumentationTest.kt
+++ b/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/ApiDocumentationTest.kt
@@ -1,0 +1,71 @@
+package me.helloc.techwikiplus.documentation
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+/**
+ * API 문서화를 위한 기본 테스트 클래스
+ *
+ * 이 클래스는 REST Docs와 restdocs-api-spec을 사용하여
+ * API 문서를 자동으로 생성하는 테스트의 기반 클래스입니다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(RestDocumentationExtension::class)
+abstract class ApiDocumentationTest {
+    @Autowired
+    protected lateinit var mockMvc: MockMvc
+
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var context: WebApplicationContext
+
+    @BeforeEach
+    fun setUp(restDocumentation: RestDocumentationContextProvider) {
+        this.mockMvc =
+            MockMvcBuilders.webAppContextSetup(context)
+                .apply<DefaultMockMvcBuilder>(
+                    documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()),
+                )
+                .build()
+    }
+
+    /**
+     * 문서화를 위한 헬퍼 메서드
+     *
+     * @param identifier 문서 식별자
+     * @param resourceParameters 리소스 파라미터
+     * @return 문서화 설정이 적용된 ResultHandler
+     */
+    protected fun documentWithResource(
+        identifier: String,
+        resourceParameters: ResourceSnippetParameters,
+    ) = document(
+        identifier,
+        preprocessRequest(prettyPrint()),
+        preprocessResponse(prettyPrint()),
+        ResourceDocumentation.resource(resourceParameters),
+    )
+}

--- a/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/HealthCheckApiDocumentationTest.kt
+++ b/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/HealthCheckApiDocumentationTest.kt
@@ -1,0 +1,72 @@
+package me.helloc.techwikiplus.documentation
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Health Check API 문서화 테스트
+ *
+ * 이 테스트는 Health Check API의 동작을 검증하고
+ * 동시에 API 문서를 자동으로 생성합니다.
+ */
+@TestPropertySource(
+    properties = [
+        "spring.application.name=techwikiplus-user",
+        "spring.application.version=1.0.0",
+    ],
+)
+class HealthCheckApiDocumentationTest : ApiDocumentationTest() {
+    @Test
+    fun `GET health - 서비스 상태 조회`() {
+        // given
+        val expectedStatus = "UP"
+        val expectedVersion = "1.0.0"
+        val expectedServiceName = "techwikiplus-user"
+
+        // when & then
+        mockMvc.perform(
+            get("/health")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(expectedStatus))
+            .andExpect(jsonPath("$.version").value(expectedVersion))
+            .andExpect(jsonPath("$.serviceName").value(expectedServiceName))
+            .andDo(
+                documentWithResource(
+                    "health-check",
+                    ResourceSnippetParameters.builder()
+                        .tag("Health Check")
+                        .summary("서비스 상태 확인")
+                        .description(
+                            """
+                            서비스의 현재 상태를 확인합니다.
+                            
+                            이 엔드포인트는 로드 밸런서나 모니터링 시스템에서
+                            서비스의 가용성을 확인하는 데 사용됩니다.
+                            """.trimIndent(),
+                        )
+                        .responseFields(
+                            fieldWithPath("status")
+                                .type(JsonFieldType.STRING)
+                                .description("서비스 상태 (UP/DOWN)"),
+                            fieldWithPath("version")
+                                .type(JsonFieldType.STRING)
+                                .description("서비스 버전"),
+                            fieldWithPath("serviceName")
+                                .type(JsonFieldType.STRING)
+                                .description("서비스 이름"),
+                        )
+                        .build(),
+                ),
+            )
+    }
+}

--- a/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/HealthCheckApiDocumentationTest.kt
+++ b/service/user/src/test/kotlin/me/helloc/techwikiplus/documentation/HealthCheckApiDocumentationTest.kt
@@ -1,6 +1,8 @@
 package me.helloc.techwikiplus.documentation
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters
+import com.epages.restdocs.apispec.Schema.Companion.schema
+import me.helloc.techwikiplus.interfaces.dto.HealthCheckResponse
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.restdocs.payload.JsonFieldType
@@ -19,18 +21,18 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @TestPropertySource(
     properties = [
         "spring.application.name=techwikiplus-user",
-        "spring.application.version=1.0.0",
+        "spring.application.version=TEST_VERSION",
     ],
 )
 class HealthCheckApiDocumentationTest : ApiDocumentationTest() {
     @Test
-    fun `GET health - 서비스 상태 조회`() {
+    fun `GET health - retrieve service status`() {
         // given
         val expectedStatus = "UP"
-        val expectedVersion = "1.0.0"
+        val expectedVersion = "TEST_VERSION"
         val expectedServiceName = "techwikiplus-user"
 
-        // when & then
+        // when and then
         mockMvc.perform(
             get("/health")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -49,7 +51,7 @@ class HealthCheckApiDocumentationTest : ApiDocumentationTest() {
                         .description(
                             """
                             서비스의 현재 상태를 확인합니다.
-                            
+
                             이 엔드포인트는 로드 밸런서나 모니터링 시스템에서
                             서비스의 가용성을 확인하는 데 사용됩니다.
                             """.trimIndent(),
@@ -64,6 +66,9 @@ class HealthCheckApiDocumentationTest : ApiDocumentationTest() {
                             fieldWithPath("serviceName")
                                 .type(JsonFieldType.STRING)
                                 .description("서비스 이름"),
+                        )
+                        .responseSchema(
+                            schema(HealthCheckResponse::class.java.simpleName),
                         )
                         .build(),
                 ),


### PR DESCRIPTION
## Summary
- Spring REST Docs와 OpenAPI 3.0을 통합하여 API 문서 자동 생성 기능 구현
- Swagger UI를 통한 대화형 API 문서 제공
- 테스트 기반 문서화로 정확성 보장

## Changes
### 🚀 Features
- **API 문서화 도구 통합**
  - Spring REST Docs + OpenAPI 3.0 통합 설정
  - 테스트 실행 시 자동으로 OpenAPI 문서 생성
  - `/api-docs/openapi3.yml`로 OpenAPI 스펙 제공
  - Swagger UI를 통한 대화형 문서 제공 (`/swagger-ui/index.html`)

- **정적 리소스 라우팅 설정**
  - REST Docs로 생성된 OpenAPI 문서를 정적 리소스로 서빙
  - `StaticRoutingConfiguration` 추가로 문서 접근 가능

### 🧪 Tests
- `ApiDocumentationTest` 베이스 클래스 추가로 문서화 테스트 표준화
- `HealthCheckApiDocumentationTest` 추가로 Health Check API 문서화
- 테스트 실행 시 자동으로 API 문서 생성 및 검증

### 🔧 Configuration
- **빌드 설정**
  - REST Docs와 OpenAPI 관련 의존성 추가
  - OpenAPI 문서 생성을 위한 Gradle 태스크 설정
  - 환경 변수 기반 동적 서버 URL 설정

- **환경 변수 정렬**
  - `SERVER_HOST`, `SERVER_PORT`, `IMAGE_TAG` 등 일관된 환경 변수 사용
  - Docker Compose 및 빌드 설정에서 동일한 환경 변수 참조

### 🐛 Bug Fixes
- Hibernate deprecated 설정 업데이트
  - `hibernate.temp.use_jdbc_metadata_defaults` → `hibernate.boot.allow_jdbc_metadata_access`
  - 명시적 MySQL dialect 설정 제거 (자동 감지 사용)

### 📝 Documentation
- README 파일명 업데이트 (실제 파일명과 일치하도록 수정)

## Test Plan
- [x] 애플리케이션 정상 실행 확인
- [x] `/health` 엔드포인트 동작 확인
- [x] API 문서 생성 확인 (`./gradlew :service:user:openapi3`)
- [x] Swagger UI 접근 확인 (`http://localhost:9000/swagger-ui/index.html`)
- [x] OpenAPI 스펙 접근 확인 (`http://localhost:9000/api-docs/openapi3.yml`)
- [x] Hibernate 경고 메시지 해결 확인

🤖 Generated with [Claude Code](https://claude.ai/code)