### PR TITLE
fix: CD 파이프라인 트리거 문제 해결

### DIFF
--- a/.github/workflows/README_CD_PIPELINE_FIX.md
+++ b/.github/workflows/README_CD_PIPELINE_FIX.md
@@ -1,0 +1,129 @@
+# CD Pipeline Fix Documentation
+
+## Problem Summary
+The CD pipeline was not triggering after PR merges because the CI workflow had its `push` trigger removed on 2025-08-01. Since the CD workflow depends on CI completion on the main branch via `workflow_run` trigger, removing the push trigger broke the CI→CD chain.
+
+## Solution Implemented
+1. **Restored the `push` trigger** to the CI workflow for the main branch
+2. **Added smart filtering** to prevent duplicate work on merge commits:
+   - The basic CI job always runs (to trigger CD)
+   - Expensive jobs (linter, test, compile-check) skip merge commits
+   - Docker build already had PR-only condition
+3. **Updated summary job** to handle merge commit scenarios gracefully
+
+## How It Works Now
+1. When a PR is opened/updated: Full CI runs (all checks + docker build)
+2. When PR is merged to main:
+   - CI workflow triggers with minimal execution
+   - Only the `ci` and `summary` jobs run
+   - Other jobs are skipped (they already ran on the PR)
+   - CD workflow triggers when CI completes successfully
+
+## Monitoring Recommendations
+
+### 1. Set Up Workflow Alerts
+Create a GitHub Action to monitor CD pipeline health:
+
+```yaml
+name: CD Pipeline Monitor
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
+
+jobs:
+  check-cd-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check recent CD runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'user-service-cd.yml',
+              per_page: 10
+            });
+            
+            const recentRuns = runs.workflow_runs.filter(run => 
+              new Date(run.created_at) > new Date(Date.now() - 24 * 60 * 60 * 1000)
+            );
+            
+            if (recentRuns.length === 0) {
+              core.setFailed('No CD runs in the last 24 hours!');
+            }
+```
+
+### 2. Add Workflow Dependencies Validation
+Add this check to your CI workflow:
+
+```yaml
+  validate-cd-trigger:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Validate CD will trigger
+        run: |
+          echo "✅ This workflow run should trigger CD pipeline"
+          echo "Event: ${{ github.event_name }}"
+          echo "Branch: ${{ github.ref }}"
+```
+
+### 3. Create a Dashboard
+Use GitHub Insights or create a simple status page that shows:
+- Last successful CD run
+- Time since last deployment
+- CI→CD trigger success rate
+
+### 4. Set Up Notifications
+Configure GitHub notifications or use a webhook to alert when:
+- CD hasn't run for > 24 hours
+- CD workflow fails
+- CI completes on main but CD doesn't start within 5 minutes
+
+## Best Practices Going Forward
+
+1. **Never remove workflow triggers without checking dependencies**
+   - Use `gh api` to check which workflows depend on others
+   - Document workflow dependencies in the workflow files
+
+2. **Test workflow changes in a separate branch**
+   - Create a test workflow file with different name
+   - Verify behavior before modifying production workflows
+
+3. **Add explicit documentation in workflows**
+   ```yaml
+   # IMPORTANT: This workflow triggers the CD pipeline
+   # DO NOT remove the push trigger without updating CD workflow
+   ```
+
+4. **Use workflow_call instead of workflow_run for tighter coupling**
+   - Consider refactoring to use reusable workflows
+   - This makes dependencies more explicit
+
+## Verification Steps
+After implementing this fix:
+
+1. Create a test PR with a small change
+2. Merge the PR
+3. Verify:
+   - CI runs on main (with most jobs skipped)
+   - CD triggers after CI completes
+   - Deployment succeeds
+
+## Alternative Approaches (Not Implemented)
+
+1. **Direct CD trigger on push to main**
+   - Pros: Simpler, no dependency chain
+   - Cons: Loses CI status gate, might deploy broken code
+
+2. **Use pull_request closed event**
+   - Pros: More explicit about when to deploy
+   - Cons: Doesn't handle direct pushes to main
+
+3. **Separate minimal CI for main pushes**
+   - Pros: Clear separation of concerns
+   - Cons: More workflows to maintain
+
+The current solution balances simplicity with the existing architecture while preventing duplicate work.

--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -5,9 +5,18 @@ name: User Service CI
 # Removed deprecated cache-encryption-key and gradle-home-cache-strict-match options.
 # Added enhanced debugging for build failures.
 # Updated 2025-07-30: Replaced deprecated gradle-home-cache-cleanup with cache-cleanup parameter.
-# Updated 2025-08-01: Removed push trigger to prevent duplicate CI runs on PR merge
+# Updated 2025-08-01: Added push trigger back with proper filtering to maintain CD pipeline
+# The push trigger is required because CD workflow depends on CI completion on main branch
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'common/**'
+      - 'service/user/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/workflows/user-service-ci.yml'
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
@@ -78,6 +87,8 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     name: Code Style Check (ktlint)
+    # Skip on merge commits since PR already ran these checks
+    if: ${{ github.event_name == 'pull_request' || !contains(github.event.head_commit.message, 'Merge pull request') }}
 
     steps:
       - name: Checkout repository
@@ -153,6 +164,8 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     name: Run Tests
+    # Skip on merge commits since PR already ran these checks
+    if: ${{ github.event_name == 'pull_request' || !contains(github.event.head_commit.message, 'Merge pull request') }}
 
     steps:
       - name: Checkout repository
@@ -251,6 +264,8 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     name: Compile Check
+    # Skip on merge commits since PR already ran these checks
+    if: ${{ github.event_name == 'pull_request' || !contains(github.event.head_commit.message, 'Merge pull request') }}
 
     steps:
       - name: Checkout repository
@@ -573,27 +588,35 @@ jobs:
           echo "## 📊 Overall CI Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Check job statuses
-          ALL_SUCCESS=true
-          if [ "${{ needs.linter.result }}" == "success" ] &&
-             [ "${{ needs.test.result }}" == "success" ] &&
-             [ "${{ needs.compile-check.result }}" == "success" ]; then
-            # Check Docker job result
-            if [ "${{ needs.docker-build-push.result }}" == "success" ] || [ "${{ needs.docker-build-push.result }}" == "skipped" ]; then
-              echo "### ✅ All CI checks passed successfully!" >> $GITHUB_STEP_SUMMARY
+          # Check if this is a merge commit
+          if [[ "${{ github.event.head_commit.message }}" == *"Merge pull request"* ]] && [ "${{ github.event_name }}" == "push" ]; then
+            echo "### ✅ Merge commit detected - CI run completed to trigger CD" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This is a merge commit from a PR. The actual CI checks were already performed on the PR." >> $GITHUB_STEP_SUMMARY
+            echo "This workflow run exists solely to trigger the CD pipeline." >> $GITHUB_STEP_SUMMARY
+          else
+            # Check job statuses for regular runs
+            ALL_SUCCESS=true
+            if [ "${{ needs.linter.result }}" == "success" ] &&
+               [ "${{ needs.test.result }}" == "success" ] &&
+               [ "${{ needs.compile-check.result }}" == "success" ]; then
+              # Check Docker job result
+              if [ "${{ needs.docker-build-push.result }}" == "success" ] || [ "${{ needs.docker-build-push.result }}" == "skipped" ]; then
+                echo "### ✅ All CI checks passed successfully!" >> $GITHUB_STEP_SUMMARY
+              else
+                ALL_SUCCESS=false
+              fi
             else
               ALL_SUCCESS=false
             fi
-          else
-            ALL_SUCCESS=false
           fi
 
-          if [ "$ALL_SUCCESS" == "false" ]; then
+          if [ "$ALL_SUCCESS" == "false" ] && [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
             echo "### ❌ Some CI checks failed:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.linter.result }}" != "success" ] && echo "- ❌ Code Style Check: ${{ needs.linter.result }}" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.test.result }}" != "success" ] && echo "- ❌ Tests: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.compile-check.result }}" != "success" ] && echo "- ❌ Compile Check: ${{ needs.compile-check.result }}" >> $GITHUB_STEP_SUMMARY
+            [ "${{ needs.linter.result }}" != "success" ] && [ "${{ needs.linter.result }}" != "skipped" ] && echo "- ❌ Code Style Check: ${{ needs.linter.result }}" >> $GITHUB_STEP_SUMMARY
+            [ "${{ needs.test.result }}" != "success" ] && [ "${{ needs.test.result }}" != "skipped" ] && echo "- ❌ Tests: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
+            [ "${{ needs.compile-check.result }}" != "success" ] && [ "${{ needs.compile-check.result }}" != "skipped" ] && echo "- ❌ Compile Check: ${{ needs.compile-check.result }}" >> $GITHUB_STEP_SUMMARY
 
             # Show Docker status
             [ "${{ needs.docker-build-push.result }}" != "success" ] && [ "${{ needs.docker-build-push.result }}" != "skipped" ] && echo "- ❌ Docker Build & Push: ${{ needs.docker-build-push.result }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 요약
- CI 워크플로우에 push 트리거를 다시 추가하여 CD 파이프라인이 정상적으로 실행되도록 수정
- 머지 커밋에서는 중복 작업을 방지하기 위해 조건부 실행 로직 추가
- CD 파이프라인 모니터링 가이드 문서 작성

## 문제 상황
PR #8이 main 브랜치에 머지되었지만 CD 파이프라인이 실행되지 않았습니다.

### 근본 원인
1. CD 워크플로우는 CI 완료 시 `workflow_run` 트리거로 실행되도록 설정됨
2. CI 워크플로우에서 push 트리거가 제거되어 있어 PR 머지 시 CI가 실행되지 않음
3. CI가 실행되지 않으니 CD도 트리거되지 않는 상황 발생

## 변경 사항
### CI 워크플로우 수정 (`.github/workflows/user-service-ci.yml`)
1. **push 트리거 복원**: main 브랜치로의 push 이벤트 트리거 추가
2. **조건부 실행 추가**: 머지 커밋에서는 비용이 큰 작업들(linter, test, compile-check)을 건너뛰도록 설정
   - `if: ${{ github.event_name == 'pull_request' || \!contains(github.event.head_commit.message, 'Merge pull request') }}`
3. **summary job 업데이트**: 머지 커밋 시나리오를 gracefully 처리하도록 수정

### 문서 추가 (`.github/workflows/README_CD_PIPELINE_FIX.md`)
- CD 파이프라인 모니터링 및 관리 가이드
- 워크플로우 상태 확인 방법
- 트러블슈팅 가이드
- 베스트 프랙티스

## 결과
- PR 머지 시 CI가 실행되어 CD 파이프라인이 정상적으로 트리거됨
- 중복 작업 없이 효율적인 파이프라인 실행
- 명확한 워크플로우 상태 리포팅

## 테스트 계획
- [ ] CI 워크플로우가 PR에서 정상 실행되는지 확인
- [ ] 머지 후 CI가 실행되고 CD가 트리거되는지 확인
- [ ] 머지 커밋에서 중복 작업이 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)