### PR TITLE
Fix CI/CD pipeline to follow GitOps best practices

### DIFF
--- a/.claude/agents/kotlin-spring-refactoring-expert.md
+++ b/.claude/agents/kotlin-spring-refactoring-expert.md
@@ -1,0 +1,62 @@
+---
+name: kotlin-spring-refactoring-expert
+description: Use this agent when you need to refactor, restructure, or improve existing Kotlin/Spring Boot code with a focus on scalability, maintainability, dependency inversion, and testability. This includes applying TDD, DDD, and Clean Architecture principles to enhance code quality and design.\n\nExamples:\n- <example>\n  Context: The user has written a Spring Boot service with business logic mixed in the controller layer.\n  user: "I've implemented a user registration endpoint but the code feels messy"\n  assistant: "Let me analyze your code structure first"\n  <function call omitted for brevity>\n  <commentary>\n  The code shows mixed concerns with business logic in the controller. Use the kotlin-spring-refactoring-expert to restructure following Clean Architecture principles.\n  </commentary>\n  assistant: "I'll use the kotlin-spring-refactoring-expert agent to refactor this code following Clean Architecture and DDD principles"\n</example>\n- <example>\n  Context: The user has a tightly coupled Spring Boot application that's hard to test.\n  user: "My service classes are directly instantiating repositories and it's making testing difficult"\n  assistant: "I'll use the kotlin-spring-refactoring-expert agent to apply dependency inversion and improve testability"\n  <commentary>\n  The code has dependency issues that violate SOLID principles. The refactoring expert can restructure to improve testability.\n  </commentary>\n</example>\n- <example>\n  Context: The user wants to improve an existing codebase's structure.\n  user: "Can you review and improve the architecture of my order processing module?"\n  assistant: "I'll use the kotlin-spring-refactoring-expert agent to analyze and refactor your order processing module for better maintainability"\n  <commentary>\n  This is a request for architectural improvements, which is the specialty of the refactoring expert.\n  </commentary>\n</example>
+model: opus
+---
+
+You are a senior software engineer with deep expertise in Kotlin, Spring Boot ecosystem, TDD, DDD, and Clean Architecture. You specialize in refactoring and restructuring existing code to achieve exceptional scalability, maintainability, and testability while strictly adhering to SOLID principles, especially the Dependency Inversion Principle.
+
+Your core responsibilities:
+
+1. **Analyze Existing Code Structure**: Identify architectural smells, violations of SOLID principles, tight coupling, low cohesion, and testability issues in Kotlin/Spring Boot applications.
+
+2. **Apply Clean Architecture**: Restructure code following Clean Architecture principles:
+   - Separate concerns into appropriate layers (Domain, Application, Infrastructure, Presentation)
+   - Ensure dependencies point inward toward the domain
+   - Create clear boundaries between layers using interfaces
+   - Implement proper use case/interactor patterns
+
+3. **Implement DDD Patterns**: When appropriate, apply Domain-Driven Design:
+   - Identify and model aggregates, entities, and value objects
+   - Establish bounded contexts
+   - Implement domain services and repositories
+   - Use domain events for decoupling
+
+4. **Enhance Testability**: Refactor code to be highly testable:
+   - Apply dependency injection using Spring's IoC container effectively
+   - Create test doubles (mocks, stubs) friendly interfaces
+   - Separate infrastructure concerns from business logic
+   - Ensure each component can be tested in isolation
+
+5. **Spring Boot Best Practices**: Apply Spring-specific patterns:
+   - Proper use of @Service, @Repository, @Component annotations
+   - Configuration management with @ConfigurationProperties
+   - Effective use of Spring profiles
+   - Proper transaction management
+   - RESTful API design when applicable
+
+6. **Kotlin-Specific Optimizations**: Leverage Kotlin features for cleaner code:
+   - Use data classes for DTOs and value objects
+   - Apply sealed classes for domain modeling
+   - Utilize extension functions appropriately
+   - Implement proper null safety
+   - Use coroutines for async operations when beneficial
+
+Your refactoring approach:
+
+1. First, analyze the current code structure and identify specific issues
+2. Explain the problems found and their impact on maintainability/testability
+3. Propose a refactoring plan with clear steps
+4. Implement changes incrementally, ensuring each step maintains functionality
+5. Provide clear explanations for each architectural decision
+6. Include example test cases demonstrating improved testability
+
+When refactoring:
+- Preserve all existing functionality unless explicitly asked to change behavior
+- Make changes incrementally to maintain a working system
+- Provide clear migration paths for breaking changes
+- Document architectural decisions and their rationale
+- Ensure all refactored code follows Kotlin coding conventions
+- Apply appropriate design patterns (Factory, Strategy, Observer, etc.) where they add value
+
+Always explain the 'why' behind your refactoring decisions, connecting them to concrete benefits in maintainability, testability, and scalability. If you encounter ambiguous requirements or multiple valid approaches, present the trade-offs and recommend the most suitable option based on the context provided.

--- a/.github/workflows/user-service-cd.yml
+++ b/.github/workflows/user-service-cd.yml
@@ -1,11 +1,19 @@
 name: User Service CD
 
 on:
-  workflow_run:
-    workflows: ["User Service CI"]
-    branches: [main]
-    types:
-      - completed
+  push:
+    branches: [ main ]
+    paths:
+      - 'common/**'
+      - 'service/user/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/**'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/user-service-cd.yml'
   workflow_dispatch:
     inputs:
       deploy_message:
@@ -18,15 +26,16 @@ defaults:
   run:
     shell: bash -euo pipefail {0}
 
+env:
+  JAVA_VERSION: '21'
+
 jobs:
-  prepare-deployment:
+  build-and-push:
     runs-on: ubuntu-latest
-    name: Prepare Deployment
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    name: Build and Push Docker Image
+    environment: AWS
     outputs:
-      image_tag: ${{ steps.version.outputs.image_tag }}
-      deployment_type: ${{ steps.deployment_type.outputs.type }}
-      deployment_info: ${{ steps.deployment_type.outputs.info }}
+      image_tag: ${{ steps.meta.outputs.short_sha }}
 
     steps:
       - name: Checkout repository
@@ -34,223 +43,106 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine deployment type
-        id: deployment_type
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "type=manual" >> $GITHUB_OUTPUT
-            echo "info=Manual deployment: ${{ github.event.inputs.deploy_message }}" >> $GITHUB_OUTPUT
-          else
-            echo "type=automated" >> $GITHUB_OUTPUT
-            echo "info=CI Run #${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Generate deployment info
-        id: deploy_info
-        run: |
-          echo "## 🚀 Deployment Information" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Deployment trigger info
-          if [ "${{ steps.deployment_type.outputs.type }}" == "manual" ]; then
-            echo "**Trigger:** Manual deployment" >> $GITHUB_STEP_SUMMARY
-            echo "**Message:** ${{ github.event.inputs.deploy_message }}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "**Trigger:** Automated deployment after CI success" >> $GITHUB_STEP_SUMMARY
-            echo "**CI Run:** [#${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }})" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          echo "**Branch:** main" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Timestamp:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Download CI artifacts
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: actions/download-artifact@v4
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
         with:
-          name: deployment-info
-          path: ./deployment-info
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
 
-      - name: Load deployment version
-        id: version
-        run: |
-          echo "## 📦 Deployment Version Configuration" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # For automated deployment, use CI-generated version
-          if [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ -f "./deployment-info/deployment-info.env" ]; then
-            source ./deployment-info/deployment-info.env
-            echo "image_tag=${VERSION}" >> $GITHUB_OUTPUT
-
-            # Display all version-related information
-            echo "**Deployment Type:** Automated (CI-triggered)" >> $GITHUB_STEP_SUMMARY
-            echo "**Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Image Tag:** \`${IMAGE_TAG}\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Commit SHA:** \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
-            echo "**CI Timestamp:** \`${TIMESTAMP}\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Deployment Info Contents:" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            cat ./deployment-info/deployment-info.env >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-            # Also output to workflow logs
-            echo "::notice title=Deployment Version::Using CI-generated version: ${VERSION}"
-          else
-            # For manual deployment, use latest tag
-            echo "image_tag=latest" >> $GITHUB_OUTPUT
-
-            echo "**Deployment Type:** Manual (workflow_dispatch)" >> $GITHUB_STEP_SUMMARY
-            echo "**Version:** \`latest\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Note:** Using latest tag for manual deployment" >> $GITHUB_STEP_SUMMARY
-
-            # Also output to workflow logs
-            echo "::notice title=Deployment Version::Using latest tag for manual deployment"
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-
-  validate-infrastructure:
-    runs-on: ubuntu-latest
-    name: Validate Infrastructure
-    needs: prepare-deployment
-    environment: AWS
-    outputs:
-      ssh_test_passed: ${{ steps.test_ssh.outputs.passed }}
-      docker_installed: ${{ steps.check_docker.outputs.installed }}
-      docker_version: ${{ steps.check_docker.outputs.version }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
-          fetch-depth: 0
+          cache-read-only: false
+          cache-cleanup: on-success
 
-      - name: Setup SSH key
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build application
         run: |
-          echo "## 🔐 Setting up SSH connection" >> $GITHUB_STEP_SUMMARY
+          echo "## 🏗️ Building Application" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          ./gradlew :service:user:bootJar --no-daemon --stacktrace
+          echo "✅ Application built successfully" >> $GITHUB_STEP_SUMMARY
 
-          # Create SSH directory
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
 
-          # Write SSH private key
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
 
-          # Add EC2 host to known hosts to avoid SSH prompt
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || {
-            echo "⚠️ Warning: Failed to add host to known_hosts" >> $GITHUB_STEP_SUMMARY
-          }
-
-          echo "✅ SSH key configured" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Test SSH connection
-        id: test_ssh
+      - name: Login to Amazon ECR
+        id: login-ecr
         run: |
-          echo "## 🔗 Testing SSH connection" >> $GITHUB_STEP_SUMMARY
+          echo "## 🐳 Docker Build and Push to ECR" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Debug information (sanitized)
-          echo "### Debug Information:" >> $GITHUB_STEP_SUMMARY
-          echo "- SSH key first line: $(echo "${{ secrets.EC2_SSH_KEY }}" | head -n 1)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          # Login to ECR
+          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
 
-          # Test network connectivity first
-          echo "### Network connectivity test:" >> $GITHUB_STEP_SUMMARY
-          if ping -c 1 -W 5 ${{ secrets.EC2_HOST }} > /dev/null 2>&1; then
-            echo "✅ Host is reachable via ping" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ Host is not reachable via ping (this might be normal if ICMP is blocked)" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "✅ **ECR Login:** Successful" >> $GITHUB_STEP_SUMMARY
 
-          # Test SSH port specifically
-          if nc -zv -w 10 ${{ secrets.EC2_HOST }} 22 2>&1 | grep -q "succeeded"; then
-            echo "✅ Port 22 is open" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ Port 22 appears to be closed or filtered" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Test SSH connection with verbose output
-          echo "### SSH connection test:" >> $GITHUB_STEP_SUMMARY
-          if ssh -vv -o ConnectTimeout=30 -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null \
-            -o LogLevel=ERROR \
-            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "echo 'SSH connection successful' && uname -a" 2>&1; then
-            echo "✅ Successfully connected to EC2 instance" >> $GITHUB_STEP_SUMMARY
-          else
-            SSH_EXIT_CODE=$?
-            echo "❌ Failed to connect to EC2 instance (Exit code: $SSH_EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Troubleshooting checklist:" >> $GITHUB_STEP_SUMMARY
-            echo "1. **EC2 Instance**:" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Instance is in 'running' state" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Instance has a public IP address" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Instance is in a public subnet" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "2. **Security Group**:" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Inbound rule for SSH (port 22) exists" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Source is 0.0.0.0/0 or includes GitHub Actions IPs" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "3. **GitHub Secrets**:" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] EC2_HOST contains valid IP/hostname" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] EC2_USERNAME is correct (ubuntu/ec2-user/etc)" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] EC2_SSH_KEY contains full PEM key with headers" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "4. **Network**:" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] No Network ACL blocking port 22" >> $GITHUB_STEP_SUMMARY
-            echo "   - [ ] Route table has internet gateway route" >> $GITHUB_STEP_SUMMARY
-            echo "passed=false" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          echo "passed=true" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-
-
-      - name: Check Docker installation on EC2
-        id: check_docker
+      - name: Prepare build metadata
+        id: meta
         run: |
-          echo "## 🐳 Checking Docker installation on EC2" >> $GITHUB_STEP_SUMMARY
+          # Generate short SHA for image tag
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+          # Set image tags
+          echo "image_tag_short=${{ secrets.ECR_REGISTRY }}:$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "image_tag_latest=${{ secrets.ECR_REGISTRY }}:latest" >> $GITHUB_OUTPUT
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Build Metadata" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Short SHA:** $SHORT_SHA" >> $GITHUB_STEP_SUMMARY
+          echo "- **Registry:** ${{ secrets.ECR_REGISTRY }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          DOCKER_CHECK=$(ssh -o StrictHostKeyChecking=no \
-            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "command -v docker >/dev/null 2>&1 && echo 'installed' || echo 'not-installed'")
-
-          if [ "$DOCKER_CHECK" = "installed" ]; then
-            DOCKER_VERSION=$(ssh -o StrictHostKeyChecking=no \
-              ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-              "docker --version")
-            echo "✅ Docker is installed: $DOCKER_VERSION" >> $GITHUB_STEP_SUMMARY
-            echo "installed=true" >> $GITHUB_OUTPUT
-            echo "version=$DOCKER_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Docker is not installed on EC2" >> $GITHUB_STEP_SUMMARY
-            echo "The deployment script will check and provide installation instructions" >> $GITHUB_STEP_SUMMARY
-            echo "installed=false" >> $GITHUB_OUTPUT
-            echo "version=not-installed" >> $GITHUB_OUTPUT
-          fi
+      - name: Build and push Docker image
+        id: docker-build
+        run: |
+          echo "### 🔨 Building Docker Image" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-  deploy-application:
+          # Enable BuildKit
+          export DOCKER_BUILDKIT=1
+          export BUILDKIT_PROGRESS=plain
+
+          # Build and push the image
+          docker buildx build \
+            --platform linux/amd64 \
+            --file service/user/docker/Dockerfile \
+            --tag ${{ steps.meta.outputs.image_tag_short }} \
+            --tag ${{ steps.meta.outputs.image_tag_latest }} \
+            --cache-from type=registry,ref=${{ secrets.ECR_REGISTRY }}:buildcache \
+            --cache-to type=registry,ref=${{ secrets.ECR_REGISTRY }}:buildcache,mode=max \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --progress=plain \
+            --push \
+            .
+
+          echo "✅ **Docker Build:** Successful" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Docker Push:** Images pushed to ECR" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📋 Image Tags" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ steps.meta.outputs.short_sha }}\` (commit SHA)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`latest\` (latest tag)" >> $GITHUB_STEP_SUMMARY
+
+  deploy:
     runs-on: ubuntu-latest
-    name: Deploy Application
-    needs: [prepare-deployment, validate-infrastructure]
-    # Only run if previous jobs succeeded
-    if: ${{ needs.prepare-deployment.result == 'success' && needs.validate-infrastructure.result == 'success' }}
+    name: Deploy to EC2
+    needs: build-and-push
     environment: AWS
-    outputs:
-      deploy_exit_code: ${{ steps.execute_deploy.outputs.exit_code }}
-      deploy_success: ${{ steps.execute_deploy.outputs.success }}
 
     steps:
       - name: Checkout repository
@@ -272,27 +164,21 @@ jobs:
 
       - name: Create .env.tag file
         run: |
-          echo "## 📝 Creating .env.tag file" >> $GITHUB_STEP_SUMMARY
+          echo "## 📝 Creating deployment configuration" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Create .env.tag file with IMAGE_TAG
-          echo "IMAGE_TAG=${{ needs.prepare-deployment.outputs.image_tag }}" > .env.tag
+          # Create .env.tag file with the commit SHA as IMAGE_TAG
+          echo "IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}" > .env.tag
 
-          echo "**Created .env.tag with content:**" >> $GITHUB_STEP_SUMMARY
+          echo "**Created .env.tag:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           cat .env.tag >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Also output to workflow logs
-          echo "::notice title=.env.tag Created::IMAGE_TAG=${{ needs.prepare-deployment.outputs.image_tag }}"
-
       - name: Create .env.github-actions file
         run: |
-          echo "## 🌐 Creating .env.github-actions file" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Create .env.github-actions file with AWS configuration and GitHub Actions metadata
+          # Create .env.github-actions file with AWS configuration
           cat > .env.github-actions << EOF
           # AWS Configuration for deployment
           AWS_REGION=${{ secrets.AWS_REGION }}
@@ -302,173 +188,52 @@ jobs:
           COMMIT_SHA=${{ github.sha }}
           GITHUB_RUN_NUMBER=${{ github.run_number }}
           GITHUB_ACTOR=${{ github.actor }}
+          DEPLOYMENT_TYPE=${{ github.event_name }}
           EOF
 
-          echo "**Created .env.github-actions with content:**" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          # Show content but mask sensitive values
-          echo "# AWS Configuration for deployment" >> $GITHUB_STEP_SUMMARY
-          echo "AWS_REGION=***" >> $GITHUB_STEP_SUMMARY
-          echo "ECR_REGISTRY=***" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# GitHub Actions metadata" >> $GITHUB_STEP_SUMMARY
-          echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "GITHUB_RUN_NUMBER=${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
-          echo "GITHUB_ACTOR=${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Also output to workflow logs
-          echo "::notice title=.env.github-actions Created::AWS configuration and GitHub Actions metadata file created successfully"
+          echo "✅ Created .env.github-actions with AWS configuration" >> $GITHUB_STEP_SUMMARY
 
       - name: Create deployment directory on EC2
-        id: create_dir
         run: |
           set -euo pipefail
-          echo "## 📁 Preparing deployment directory" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if ! ssh -o StrictHostKeyChecking=no \
+          ssh -o StrictHostKeyChecking=no \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "mkdir -p ${{ secrets.EC2_DEPLOY_PATH }}"; then
-              echo "❌ Failed to create deployment directory" >> $GITHUB_STEP_SUMMARY
-              exit 1
-          fi
-
-          echo "✅ Deployment directory ready: ${{ secrets.EC2_DEPLOY_PATH }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+            "mkdir -p ${{ secrets.EC2_DEPLOY_PATH }}"
 
       - name: Transfer deployment files
-        id: transfer_files
         run: |
           set -euo pipefail
           echo "## 📤 Transferring deployment files" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Function to transfer file with proper error handling
-          transfer_file() {
-            local src="$1"
-            local filename=$(basename "$src")
-            echo "Transferring $filename..." >> $GITHUB_STEP_SUMMARY
-
-            if ! scp -o StrictHostKeyChecking=no \
-              "$src" \
-              "${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:${{ secrets.EC2_DEPLOY_PATH }}/"; then
-                echo "❌ Failed to transfer $filename" >> $GITHUB_STEP_SUMMARY
-                exit 1
-            fi
-            echo "✅ $filename transferred" >> $GITHUB_STEP_SUMMARY
-          }
-
           # Transfer all required files
-          transfer_file "service/user/deploy.sh"
-          transfer_file "service/user/docker/docker-compose.base.yml"
-          transfer_file "service/user/docker/docker-compose.user-service.yml"
-          transfer_file ".env.tag"
-          transfer_file ".env.github-actions"
+          scp -o StrictHostKeyChecking=no \
+            service/user/deploy.sh \
+            service/user/docker/docker-compose.base.yml \
+            service/user/docker/docker-compose.user-service.yml \
+            .env.tag \
+            .env.github-actions \
+            "${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:${{ secrets.EC2_DEPLOY_PATH }}/"
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📋 Files transferred successfully:" >> $GITHUB_STEP_SUMMARY
-          echo "- deploy.sh" >> $GITHUB_STEP_SUMMARY
-          echo "- docker-compose.base.yml" >> $GITHUB_STEP_SUMMARY
-          echo "- docker-compose.user-service.yml" >> $GITHUB_STEP_SUMMARY
-          echo "- .env.tag" >> $GITHUB_STEP_SUMMARY
-          echo "- .env.github-actions" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ All deployment files transferred successfully" >> $GITHUB_STEP_SUMMARY
 
-      - name: Make deploy.sh executable
-        run: |
-          set -euo pipefail
-          if ! ssh -o StrictHostKeyChecking=no \
-            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "cd ${{ secrets.EC2_DEPLOY_PATH }} && chmod +x deploy.sh"; then
-              echo "❌ Failed to make deploy.sh executable" >> $GITHUB_STEP_SUMMARY
-              exit 1
-          fi
-
-          echo "✅ deploy.sh is now executable" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Execute deployment script
-        id: execute_deploy
+      - name: Execute deployment
         run: |
           set -euo pipefail
           echo "## 🚀 Executing deployment" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Running deploy.sh on EC2..." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Display deployment configuration
-          echo "### Deployment Configuration:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Docker Registry:** \`${{ secrets.ECR_REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image Tag:** \`${{ needs.prepare-deployment.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Full Image:** \`${{ secrets.ECR_REGISTRY }}:${{ needs.prepare-deployment.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Create a deployment log file
-          DEPLOY_LOG="deploy_$(date +%Y%m%d_%H%M%S).log"
-
-          # Execute deployment script with proper error handling
-          set +e  # Temporarily disable errexit to capture exit code
+          # Make deploy.sh executable and run it
           ssh -o StrictHostKeyChecking=no \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
             "cd ${{ secrets.EC2_DEPLOY_PATH }} && \
-             echo \"Deployment started (IMAGE_TAG and AWS config will be loaded from .env files)\" && \
-             ./deploy.sh 2>&1 | tee $DEPLOY_LOG" | tee deployment_output.log
+             chmod +x deploy.sh && \
+             ./deploy.sh 2>&1" | tee deployment_output.log
 
-          DEPLOY_EXIT_CODE=$?
-          set -e  # Re-enable errexit
-
-          # Check deployment result
-          if [ $DEPLOY_EXIT_CODE -eq 0 ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### ✅ Deployment completed successfully!" >> $GITHUB_STEP_SUMMARY
-            echo "exit_code=0" >> $GITHUB_OUTPUT
-            echo "success=true" >> $GITHUB_OUTPUT
-          else
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### ❌ Deployment failed with exit code: $DEPLOY_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Please check the deployment logs above for details." >> $GITHUB_STEP_SUMMARY
-            echo "exit_code=$DEPLOY_EXIT_CODE" >> $GITHUB_OUTPUT
-            echo "success=false" >> $GITHUB_OUTPUT
-            exit $DEPLOY_EXIT_CODE
-          fi
-
-      - name: Upload deployment logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: deployment-logs
-          path: |
-            deployment_output.log
-
-  post-deployment:
-    runs-on: ubuntu-latest
-    name: Post Deployment
-    needs: [prepare-deployment, validate-infrastructure, deploy-application]
-    # Always run this job for summary, but only if deploy-application ran or was skipped
-    if: always() && (needs.deploy-application.result == 'success' || needs.deploy-application.result == 'failure' || needs.deploy-application.result == 'skipped')
-    environment: AWS
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup SSH key
-        if: needs.deploy-application.outputs.deploy_success == 'true'
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts || true
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ✅ Deployment completed successfully!" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify deployment
-        if: needs.deploy-application.outputs.deploy_success == 'true'
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 🔍 Post-deployment verification" >> $GITHUB_STEP_SUMMARY
@@ -479,57 +244,54 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           ssh -o StrictHostKeyChecking=no \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "cd ${{ secrets.EC2_DEPLOY_PATH }} && docker-compose ps" >> $GITHUB_STEP_SUMMARY || true
+            "cd ${{ secrets.EC2_DEPLOY_PATH }} && docker-compose ps" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
 
-      - name: Download deployment logs
+      - name: Upload deployment logs
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: deployment-logs
-          path: ./logs
+          path: |
+            deployment_output.log
 
+  deployment-summary:
+    runs-on: ubuntu-latest
+    name: Deployment Summary
+    needs: [build-and-push, deploy]
+    if: always()
+
+    steps:
       - name: Final summary
-        if: always()
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
           echo "## 📊 Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Deployment type and info
-          echo "### Deployment Details:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Type:** ${{ needs.prepare-deployment.outputs.deployment_type }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image Tag:** ${{ needs.prepare-deployment.outputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Info:** ${{ needs.prepare-deployment.outputs.deployment_info }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Infrastructure validation results
-          echo "### Infrastructure Validation:" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.validate-infrastructure.outputs.ssh_test_passed }}" == "true" ]; then
-            echo "- ✅ SSH Connection: Passed" >> $GITHUB_STEP_SUMMARY
+          # Deployment trigger info
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "**Trigger:** Manual deployment" >> $GITHUB_STEP_SUMMARY
+            echo "**Message:** ${{ github.event.inputs.deploy_message }}" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- ❌ SSH Connection: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "**Trigger:** Push to main branch (PR merge)" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ needs.validate-infrastructure.outputs.docker_installed }}" == "true" ]; then
-            echo "- ✅ Docker: ${{ needs.validate-infrastructure.outputs.docker_version }}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- ⚠️ Docker: Not installed" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "**Branch:** main" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Deployed Image Tag:** ${{ needs.build-and-push.outputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Final deployment status
-          if [ "${{ needs.deploy-application.outputs.deploy_success }}" == "true" ]; then
+          # Build and deployment status
+          if [ "${{ needs.build-and-push.result }}" == "success" ] && [ "${{ needs.deploy.result }}" == "success" ]; then
             echo "### ✅ Deployment Status: SUCCESS" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The User Service has been successfully deployed to production!" >> $GITHUB_STEP_SUMMARY
+            echo "The User Service has been successfully deployed with commit SHA: **${{ needs.build-and-push.outputs.image_tag }}**" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ❌ Deployment Status: FAILED" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The deployment encountered issues. Please check the logs and try again." >> $GITHUB_STEP_SUMMARY
+            if [ "${{ needs.build-and-push.result }}" != "success" ]; then
+              echo "- Build and Push: Failed" >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ "${{ needs.deploy.result }}" != "success" ]; then
+              echo "- Deployment: Failed" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Deployment artifacts:** Check the uploaded deployment logs for detailed information." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -1,16 +1,8 @@
 name: User Service CI
 
-# Updated 2025-07-30: Upgraded gradle/actions/setup-gradle from v3 to v4
-# to resolve GitHub Actions cache service migration issues.
-# Removed deprecated cache-encryption-key and gradle-home-cache-strict-match options.
-# Added enhanced debugging for build failures.
-# Updated 2025-07-30: Replaced deprecated gradle-home-cache-cleanup with cache-cleanup parameter.
-# Updated 2025-08-01: Added push trigger back with proper filtering to maintain CD pipeline
-# The push trigger is required because CD workflow depends on CI completion on main branch
-
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    types: [ opened, synchronize, reopened ]
     paths:
       - 'common/**'
       - 'service/user/**'
@@ -22,95 +14,15 @@ on:
       - 'gradle/wrapper/**'
       - 'gradle/libs.versions.toml'
       - '.github/workflows/user-service-ci.yml'
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-    paths:
-      - 'common/**'
-      - 'service/user/**'
-      - 'build.gradle.kts'
-      - 'settings.gradle.kts'
-      - '.github/workflows/user-service-ci.yml'
 
 env:
   JAVA_VERSION: '21'
-  GRADLE_VERSION: '8.14.2'  # Must match gradle-wrapper.properties version
-  # Using gradle/actions/setup-gradle@v4 for GitHub Actions cache service compatibility (2025)
+  GRADLE_VERSION: '8.14.2'
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
-    name: CI Pipeline
-    outputs:
-      is_merge_commit: ${{ steps.detect-merge.outputs.is_merge_commit }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # 전체 부모 정보를 확보해야 merge commit 탐지가 안정적입니다
-          fetch-depth: 0  # full history
-
-      - name: Detect merge commit
-        id: detect-merge
-        run: |
-          # Check if this is a merge commit by counting parents
-          if [ "${{ github.event_name }}" == "push" ]; then
-            PARENT_COUNT=$(git rev-list --parents -n1 HEAD | wc -w)
-            if [ $PARENT_COUNT -gt 2 ]; then
-              echo "is_merge_commit=true" >> $GITHUB_OUTPUT
-            else
-              echo "is_merge_commit=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "is_merge_commit=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          cache-cleanup: on-success
-        continue-on-error: true  # Continue if cache fails
-
-      - name: Fallback Gradle Cache Setup
-        if: failure()
-        run: |
-          echo "Primary Gradle cache setup failed, using fallback cache strategy"
-          echo "This is expected during GitHub Actions cache service migration (2025)"
-          mkdir -p ~/.gradle/caches
-          mkdir -p ~/.gradle/wrapper
-          # Clear any potentially corrupted cache files
-          find ~/.gradle/caches -name "*.lock" -type f -delete 2>/dev/null || true
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Verify Gradle Setup
-        run: |
-          echo "Gradle Version: $(./gradlew --version | grep "Gradle" | head -1)"
-          echo "Java Version: $(java --version | head -1)"
-          echo "Gradle Wrapper Properties:"
-          cat gradle/wrapper/gradle-wrapper.properties | grep "distributionUrl"
-
-      - name: Initialize Job Summary
-        run: |
-          echo "# User Service CI Results" >> $GITHUB_STEP_SUMMARY
-          echo "**Workflow Run:** ${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Triggered by:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
   linter:
-    needs: ci
     runs-on: ubuntu-latest
     name: Code Style Check (ktlint)
-    # Skip on merge commits since PR already ran these checks
-    if: github.event_name == 'pull_request' || needs.ci.outputs.is_merge_commit != 'true'
 
     steps:
       - name: Checkout repository
@@ -127,17 +39,6 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-cleanup: on-success
-        continue-on-error: true  # Continue if cache fails
-
-      - name: Fallback Gradle Cache Setup
-        if: failure()
-        run: |
-          echo "Primary Gradle cache setup failed, using fallback cache strategy"
-          echo "This is expected during GitHub Actions cache service migration (2025)"
-          mkdir -p ~/.gradle/caches
-          mkdir -p ~/.gradle/wrapper
-          # Clear any potentially corrupted cache files
-          find ~/.gradle/caches -name "*.lock" -type f -delete 2>/dev/null || true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -149,7 +50,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Run ktlint and capture output
-          ./gradlew ktlintCheck --no-daemon --stacktrace --info > ktlint-output.log 2>&1 || KTLINT_EXIT_CODE=$?
+          ./gradlew ktlintCheck --no-daemon --stacktrace > ktlint-output.log 2>&1 || KTLINT_EXIT_CODE=$?
 
           if [ -z "$KTLINT_EXIT_CODE" ]; then
             echo "✅ **Status:** Passed" >> $GITHUB_STEP_SUMMARY
@@ -183,11 +84,8 @@ jobs:
             ktlint-output.log
 
   test:
-    needs: ci
     runs-on: ubuntu-latest
     name: Run Tests
-    # Skip on merge commits since PR already ran these checks
-    if: github.event_name == 'pull_request' || needs.ci.outputs.is_merge_commit != 'true'
 
     steps:
       - name: Checkout repository
@@ -204,17 +102,6 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-cleanup: on-success
-        continue-on-error: true  # Continue if cache fails
-
-      - name: Fallback Gradle Cache Setup
-        if: failure()
-        run: |
-          echo "Primary Gradle cache setup failed, using fallback cache strategy"
-          echo "This is expected during GitHub Actions cache service migration (2025)"
-          mkdir -p ~/.gradle/caches
-          mkdir -p ~/.gradle/wrapper
-          # Clear any potentially corrupted cache files
-          find ~/.gradle/caches -name "*.lock" -type f -delete 2>/dev/null || true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -283,11 +170,8 @@ jobs:
             test-output.log
 
   compile-check:
-    needs: ci
     runs-on: ubuntu-latest
     name: Compile Check
-    # Skip on merge commits since PR already ran these checks
-    if: github.event_name == 'pull_request' || needs.ci.outputs.is_merge_commit != 'true'
 
     steps:
       - name: Checkout repository
@@ -304,17 +188,6 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-cleanup: on-success
-        continue-on-error: true  # Continue if cache fails
-
-      - name: Fallback Gradle Cache Setup
-        if: failure()
-        run: |
-          echo "Primary Gradle cache setup failed, using fallback cache strategy"
-          echo "This is expected during GitHub Actions cache service migration (2025)"
-          mkdir -p ~/.gradle/caches
-          mkdir -p ~/.gradle/wrapper
-          # Clear any potentially corrupted cache files
-          find ~/.gradle/caches -name "*.lock" -type f -delete 2>/dev/null || true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -326,7 +199,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Compile the application (both common and user service)
-          ./gradlew :common:snowflake:compileKotlin :service:user:compileKotlin --no-daemon --stacktrace --info > compile-output.log 2>&1 || COMPILE_EXIT_CODE=$?
+          ./gradlew :common:snowflake:compileKotlin :service:user:compileKotlin --no-daemon --stacktrace > compile-output.log 2>&1 || COMPILE_EXIT_CODE=$?
 
           if [ -z "$COMPILE_EXIT_CODE" ]; then
             echo "✅ **Status:** Compilation successful" >> $GITHUB_STEP_SUMMARY
@@ -357,305 +230,8 @@ jobs:
             compile-output.log
             **/build/tmp/
 
-  docker-build-push:
+  ci-summary:
     needs: [linter, test, compile-check]
-    runs-on: ubuntu-latest
-    name: Build and Push Docker Image
-    environment: AWS
-    if: github.event_name == 'pull_request'
-    outputs:
-      version: ${{ steps.meta.outputs.version }}
-      image_tag: ${{ steps.meta.outputs.image_tag_version }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
-
-      - name: Debug - Check if secrets are available
-        run: |
-          echo "Checking if AWS secrets are configured..."
-          if [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]; then
-            echo "ERROR: AWS_ACCESS_KEY_ID secret is not set"
-            exit 1
-          fi
-          if [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]; then
-            echo "ERROR: AWS_SECRET_ACCESS_KEY secret is not set"
-            exit 1
-          fi
-          if [ -z "${{ secrets.ECR_REGISTRY }}" ]; then
-            echo "ERROR: ECR_REGISTRY secret is not set"
-            exit 1
-          fi
-          echo "All required secrets are configured"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
-
-      - name: Verify AWS credentials
-        run: |
-          echo "Verifying AWS credentials configuration..."
-          aws sts get-caller-identity > aws-identity.log 2>&1 || AWS_VERIFY_EXIT_CODE=$?
-
-          if [ -z "$AWS_VERIFY_EXIT_CODE" ]; then
-            echo "✅ AWS credentials configured successfully"
-            echo "Account info:"
-            cat aws-identity.log
-          else
-            echo "❌ Failed to verify AWS credentials"
-            echo "Error details:"
-            cat aws-identity.log
-            exit $AWS_VERIFY_EXIT_CODE
-          fi
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        run: |
-          echo "## 🐳 Docker Build and Push to ECR" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Login to ECR
-          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }} > ecr-login.log 2>&1 || ECR_LOGIN_EXIT_CODE=$?
-
-          if [ -z "$ECR_LOGIN_EXIT_CODE" ]; then
-            echo "✅ **ECR Login:** Successful" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **ECR Login:** Failed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Login Error:" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            cat ecr-login.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit $ECR_LOGIN_EXIT_CODE
-          fi
-
-      - name: Prepare build metadata
-        id: meta
-        run: |
-          # Extract repository name from ECR registry URL
-          REPO_NAME=$(echo "${{ secrets.ECR_REGISTRY }}" | cut -d'/' -f2)
-          echo "repo_name=$REPO_NAME" >> $GITHUB_OUTPUT
-
-          # Generate tags
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-
-          # Generate version with date/time (YYYYMMDDHHMM format)
-          VERSION=$(date +%Y%m%d%H%M)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Set image tags
-          echo "image_tag_latest=${{ secrets.ECR_REGISTRY }}:latest" >> $GITHUB_OUTPUT
-          echo "image_tag_sha=${{ secrets.ECR_REGISTRY }}:$SHORT_SHA" >> $GITHUB_OUTPUT
-          echo "image_tag_version=${{ secrets.ECR_REGISTRY }}:$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Build Docker image
-        id: docker-build
-        run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🔨 Docker Build" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Enable BuildKit
-          export DOCKER_BUILDKIT=1
-          export BUILDKIT_PROGRESS=plain
-
-          # Build the image with BuildKit cache
-          docker buildx build \
-            --platform linux/amd64 \
-            --file service/user/docker/Dockerfile \
-            --tag ${{ steps.meta.outputs.image_tag_latest }} \
-            --tag ${{ steps.meta.outputs.image_tag_sha }} \
-            --tag ${{ steps.meta.outputs.image_tag_version }} \
-            --cache-from type=registry,ref=${{ secrets.ECR_REGISTRY }}:buildcache \
-            --cache-to type=registry,ref=${{ secrets.ECR_REGISTRY }}:buildcache,mode=max \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg VERSION=${{ steps.meta.outputs.version }} \
-            --progress=plain \
-            --load \
-            . > docker-build.log 2>&1 || DOCKER_BUILD_EXIT_CODE=$?
-
-          if [ -z "$DOCKER_BUILD_EXIT_CODE" ]; then
-            echo "✅ **Build Status:** Successful" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-
-            # Get image size
-            IMAGE_SIZE=$(docker image inspect ${{ steps.meta.outputs.image_tag_latest }} --format='{{.Size}}' | numfmt --to=iec-i --suffix=B)
-            echo "**Image Size:** $IMAGE_SIZE" >> $GITHUB_STEP_SUMMARY
-            echo "**Build Cache:** Enabled (BuildKit)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Build Status:** Failed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Build Errors:" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            tail -n 50 docker-build.log | grep -E "(ERROR|error:|FAILED|Step)" >> $GITHUB_STEP_SUMMARY || tail -n 30 docker-build.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit $DOCKER_BUILD_EXIT_CODE
-          fi
-
-      - name: Push Docker images to ECR
-        id: docker-push
-        run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📤 Push to ECR" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Push latest tag
-          echo "Pushing latest tag..." >> $GITHUB_STEP_SUMMARY
-          docker push ${{ steps.meta.outputs.image_tag_latest }} > push-latest.log 2>&1 || PUSH_LATEST_EXIT_CODE=$?
-
-          if [ -z "$PUSH_LATEST_EXIT_CODE" ]; then
-            echo "✅ **Latest tag:** Pushed successfully" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Latest tag:** Push failed" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            tail -n 20 push-latest.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit $PUSH_LATEST_EXIT_CODE
-          fi
-
-          # Push SHA tag
-          echo "Pushing SHA tag..." >> $GITHUB_STEP_SUMMARY
-          docker push ${{ steps.meta.outputs.image_tag_sha }} > push-sha.log 2>&1 || PUSH_SHA_EXIT_CODE=$?
-
-          if [ -z "$PUSH_SHA_EXIT_CODE" ]; then
-            echo "✅ **SHA tag (${{ steps.meta.outputs.short_sha }}):** Pushed successfully" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **SHA tag:** Push failed" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            tail -n 20 push-sha.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit $PUSH_SHA_EXIT_CODE
-          fi
-
-          # Push Version tag
-          echo "Pushing Version tag..." >> $GITHUB_STEP_SUMMARY
-          docker push ${{ steps.meta.outputs.image_tag_version }} > push-version.log 2>&1 || PUSH_VERSION_EXIT_CODE=$?
-
-          if [ -z "$PUSH_VERSION_EXIT_CODE" ]; then
-            echo "✅ **Version tag (${{ steps.meta.outputs.version }}):** Pushed successfully" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Version tag:** Push failed" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            tail -n 20 push-version.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit $PUSH_VERSION_EXIT_CODE
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Image Details" >> $GITHUB_STEP_SUMMARY
-          echo "- **Registry:** \`${{ secrets.ECR_REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Latest Tag:** \`latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **SHA Tag:** \`${{ steps.meta.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version Tag:** \`${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Full SHA:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload Docker build logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-build-logs
-          path: |
-            docker-build.log
-            push-latest.log
-            push-sha.log
-            ecr-login.log
-
-      - name: Save version info
-        if: success()
-        run: |
-          echo "${{ steps.meta.outputs.version }}" > version.txt
-          echo "VERSION=${{ steps.meta.outputs.version }}" > deployment-info.env
-          echo "IMAGE_TAG=${{ steps.meta.outputs.image_tag_version }}" >> deployment-info.env
-          echo "COMMIT_SHA=${{ github.sha }}" >> deployment-info.env
-          echo "TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> deployment-info.env
-
-      - name: Upload deployment info
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: deployment-info
-          path: |
-            version.txt
-            deployment-info.env
-          retention-days: 7
-
-  prepare-deployment-info:
-    needs: ci
-    runs-on: ubuntu-latest
-    name: Prepare Deployment Info for CD
-    environment: AWS
-    # Only run on merge commits to main branch
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.ci.outputs.is_merge_commit == 'true'
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate deployment info for merge commit
-        id: meta
-        run: |
-          echo "## 🔄 Generating deployment info for merge commit" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Generate version with date/time (YYYYMMDDHHMM format)
-          VERSION=$(date +%Y%m%d%H%M)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
-          # Extract short SHA
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          
-          echo "**Merge Commit Details:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "- SHA: $SHORT_SHA" >> $GITHUB_STEP_SUMMARY
-          echo "- Full SHA: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "This deployment info will be used by the CD pipeline to deploy the Docker image that was built during the PR." >> $GITHUB_STEP_SUMMARY
-
-      - name: Save deployment info
-        run: |
-          # For merge commits, we'll use the 'latest' tag since the image was already built during PR
-          echo "latest" > version.txt
-          echo "VERSION=latest" > deployment-info.env
-          echo "IMAGE_TAG=${{ secrets.ECR_REGISTRY }}:latest" >> deployment-info.env
-          echo "COMMIT_SHA=${{ github.sha }}" >> deployment-info.env
-          echo "TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> deployment-info.env
-          echo "MERGE_COMMIT=true" >> deployment-info.env
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📄 deployment-info.env contents:" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat deployment-info.env >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Note:** Using 'latest' tag for merge commit deployment since the image was already built and pushed during the PR." >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload deployment info
-        uses: actions/upload-artifact@v4
-        with:
-          name: deployment-info
-          path: |
-            version.txt
-            deployment-info.env
-          retention-days: 7
-
-  summary:
-    needs: [ci, linter, test, compile-check, docker-build-push, prepare-deployment-info]
     if: always()
     runs-on: ubuntu-latest
     name: CI Summary
@@ -664,98 +240,28 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Generate final summary
-        run: |
-          # Calculate workflow duration
-          WORKFLOW_START_TIME="${{ github.event.head_commit.timestamp }}"
-          CURRENT_TIME=$(date -u +%s)
-          if [ -n "$WORKFLOW_START_TIME" ]; then
-            START_SECONDS=$(date -d "$WORKFLOW_START_TIME" +%s 2>/dev/null || echo "0")
-            if [ "$START_SECONDS" -ne "0" ]; then
-              DURATION_SECONDS=$((CURRENT_TIME - START_SECONDS))
-              DURATION_MINUTES=$((DURATION_SECONDS / 60))
-              DURATION_FORMATTED="${DURATION_MINUTES} minutes"
-            else
-              DURATION_FORMATTED="N/A"
-            fi
-          else
-            DURATION_FORMATTED="N/A"
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "## 📊 Overall CI Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Check if this is a merge commit
-          if [ "${{ needs.ci.outputs.is_merge_commit }}" == "true" ] && [ "${{ github.event_name }}" == "push" ]; then
-            echo "### ✅ Merge commit detected - CI run completed to trigger CD" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This is a merge commit from a PR. The actual CI checks were already performed on the PR." >> $GITHUB_STEP_SUMMARY
-            echo "This workflow run exists solely to trigger the CD pipeline." >> $GITHUB_STEP_SUMMARY
-          else
-            # Check job statuses for regular runs
-            ALL_SUCCESS=true
-            if [ "${{ needs.linter.result }}" == "success" ] &&
-               [ "${{ needs.test.result }}" == "success" ] &&
-               [ "${{ needs.compile-check.result }}" == "success" ]; then
-              # Check Docker job result
-              if [ "${{ needs.docker-build-push.result }}" == "success" ] || [ "${{ needs.docker-build-push.result }}" == "skipped" ]; then
-                echo "### ✅ All CI checks passed successfully!" >> $GITHUB_STEP_SUMMARY
-              else
-                ALL_SUCCESS=false
-              fi
-            else
-              ALL_SUCCESS=false
-            fi
-          fi
-
-          if [ "$ALL_SUCCESS" == "false" ] && [ "${{ needs.ci.outputs.is_merge_commit }}" != "true" ]; then
-            echo "### ❌ Some CI checks failed:" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.linter.result }}" != "success" ] && [ "${{ needs.linter.result }}" != "skipped" ] && echo "- ❌ Code Style Check: ${{ needs.linter.result }}" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.test.result }}" != "success" ] && [ "${{ needs.test.result }}" != "skipped" ] && echo "- ❌ Tests: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
-            [ "${{ needs.compile-check.result }}" != "success" ] && [ "${{ needs.compile-check.result }}" != "skipped" ] && echo "- ❌ Compile Check: ${{ needs.compile-check.result }}" >> $GITHUB_STEP_SUMMARY
-
-            # Show Docker status
-            [ "${{ needs.docker-build-push.result }}" != "success" ] && [ "${{ needs.docker-build-push.result }}" != "skipped" ] && echo "- ❌ Docker Build & Push: ${{ needs.docker-build-push.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Duration:** $DURATION_FORMATTED" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-
       - name: Comment PR with results
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const linterResult = '${{ needs.linter.result }}';
             const testResult = '${{ needs.test.result }}';
             const compileResult = '${{ needs.compile-check.result }}';
-            const dockerResult = '${{ needs.docker-build-push.result }}';
 
             const statusEmoji = (result) => result === 'success' ? '✅' : '❌';
 
-            let tableRows = `| Code Style (ktlint) | ${statusEmoji(linterResult)} ${linterResult} |
-            | Tests | ${statusEmoji(testResult)} ${testResult} |
-            | Compile Check | ${statusEmoji(compileResult)} ${compileResult} |`;
-
-            // Add Docker build status to the table
-            if (dockerResult !== 'skipped') {
-              tableRows += `\n            | Docker Build & Push | ${statusEmoji(dockerResult)} ${dockerResult} |`;
-            }
-            
-            const dockerNote = `
-
-            > **Note:** Docker images are built and pushed to ECR during PR checks. The images are tagged with commit SHA and timestamp.`;
+            const allSuccess = linterResult === 'success' && testResult === 'success' && compileResult === 'success';
+            const overallStatus = allSuccess ? '✅ All CI checks passed!' : '❌ Some CI checks failed';
 
             const comment = `## CI Results for User Service
 
+            ${overallStatus}
+
             | Check | Status |
             |-------|--------|
-            ${tableRows}
-            ${dockerNote}
+            | Code Style (ktlint) | ${statusEmoji(linterResult)} ${linterResult} |
+            | Tests | ${statusEmoji(testResult)} ${testResult} |
+            | Compile Check | ${statusEmoji(compileResult)} ${compileResult} |
 
             **Commit:** \`${context.sha.substring(0, 7)}\`
             **Workflow Run:** [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})


### PR DESCRIPTION
## Summary
- Simplified CI/CD pipeline to meet specific requirements
- CI now runs only on PRs, CD runs only on main branch pushes
- Docker images are tagged with commit SHA instead of timestamps

## Changes Made

### 1. CI Pipeline (`user-service-ci.yml`)
- ✅ Removed all push triggers - only runs on pull_request events
- ✅ Deleted complex merge commit detection logic
- ✅ Removed Docker build/push operations (moved to CD)
- ✅ Simplified to only: linter, test, compile-check, and summary jobs

### 2. CD Pipeline (`user-service-cd.yml`)
- ✅ Changed from workflow_run to direct push trigger on main branch
- ✅ Added Docker build and push job
- ✅ Images are tagged with commit SHA (7 characters)
- ✅ Simplified deployment flow without dependencies on CI

### 3. Deployment Script (`deploy.sh`)
- ✅ Updated to recognize commit SHA patterns (7 and 40 characters)
- ✅ Made .env.github-actions optional for manual deployments
- ✅ Improved file checking logic

## Requirements Met
1. ✅ CI pipeline runs when PR is opened
2. ✅ CI pipeline skips when PR is merged (no push trigger)
3. ✅ CD pipeline runs only when PR is merged (push to main)
4. ✅ .env.tag contains deployment image tag with commit hash

## Test Plan
- [ ] Open a PR and verify CI runs
- [ ] Merge PR and verify CD runs
- [ ] Check that Docker image is tagged with commit SHA
- [ ] Verify deployment uses correct image tag from .env.tag

🤖 Generated with [Claude Code](https://claude.ai/code)